### PR TITLE
Add race, station and centers filter in and out options

### DIFF
--- a/tally_ho/apps/tally/static/js/data_table.js
+++ b/tally_ho/apps/tally/static/js/data_table.js
@@ -74,11 +74,13 @@ $(document).ready(function () {
     let data = [];
     let selectOneIds = $('select#centers').val();
     let selectTwoIds = $('select#stations').val();
+    let raceTypeNames = $('select#filter-out-race-types').val();
 
     if (selectOneIds || selectTwoIds) {
       const items = {
         select_1_ids: selectOneIds !== null ? selectOneIds : [],
         select_2_ids: selectTwoIds !== null ? selectTwoIds : [],
+        race_type_names: raceTypeNames !== null ? raceTypeNames : [],
       };
 
       data = items;
@@ -155,12 +157,78 @@ $(document).ready(function () {
     let data = [];
     let selectOneIds = $('select#filter-in-centers').val();
     let selectTwoIds = $('select#filter-in-stations').val();
+    let raceTypeNames = $('select#filter-in-race-types').val();
 
     if (selectOneIds || selectTwoIds) {
       const items = {
         select_1_ids: selectOneIds !== null ? selectOneIds : [],
         select_2_ids: selectTwoIds !== null ? selectTwoIds : [],
+        race_type_names: raceTypeNames !== null ? raceTypeNames : [],
         filter_in: "True"
+      };
+
+      data = items;
+    }
+
+    data = data.length
+      ? data.filter((item) =>
+          Object.values(item).every((value) => typeof value !== 'undefined')
+        )
+      : data;
+
+    $('.datatable').dataTable({
+      language: dt_language,
+      order: [[0, 'desc']],
+      lengthMenu: [
+        [10, 25, 50, 100, 500],
+        [10, 25, 50, 100, 500],
+      ],
+      columnDefs: [
+        {
+          orderable: true,
+          searchable: true,
+          className: 'center',
+          targets: [0, 1],
+        },
+      ],
+      searching: true,
+      processing: true,
+      serverSide: true,
+      stateSave: true,
+      ajax: {
+        url: LIST_JSON_URL,
+        type: 'POST',
+        data: { data: JSON.stringify(data) },
+        traditional: true,
+        dataType: 'json',
+      },
+      dom:
+        "<'row'<'col-sm-1'B><'col-sm-6'l><'col-sm-5'f>>" +
+        "<'row'<'col-sm-12'tr>>" +
+        "<'row'<'col-sm-5'i><'col-sm-7'p>>",
+      buttons: [
+        {
+          extend: 'csv',
+          filename: exportFileName,
+          action: exportAction,
+          exportOptions: {
+            columns: ':visible :not(.actions)',
+          },
+        },
+      ],
+      responsive: true,
+    });
+  });
+  $('#race-report').on('click', '#filter-race-report', function () {
+    const table = $('.datatable').DataTable();
+
+    table.destroy();
+    let data = [];
+    let raceTypeNames = $('select#filter-in-race-types').val();
+
+    if (raceTypeNames ) {
+      const items = {
+        race_type_names: raceTypeNames !== null ? raceTypeNames : [],
       };
 
       data = items;

--- a/tally_ho/apps/tally/static/js/data_table.js
+++ b/tally_ho/apps/tally/static/js/data_table.js
@@ -148,6 +148,74 @@ $(document).ready(function () {
     });
   });
 
+  $('#in-report').on('click', '#filter-in-report', function () {
+    const table = $('.datatable').DataTable();
+
+    table.destroy();
+    let data = [];
+    let selectOneIds = $('select#filter-in-centers').val();
+    let selectTwoIds = $('select#filter-in-stations').val();
+
+    if (selectOneIds || selectTwoIds) {
+      const items = {
+        select_1_ids: selectOneIds !== null ? selectOneIds : [],
+        select_2_ids: selectTwoIds !== null ? selectTwoIds : [],
+        filter_in: "True"
+      };
+
+      data = items;
+    }
+
+    data = data.length
+      ? data.filter((item) =>
+          Object.values(item).every((value) => typeof value !== 'undefined')
+        )
+      : data;
+
+    $('.datatable').dataTable({
+      language: dt_language,
+      order: [[0, 'desc']],
+      lengthMenu: [
+        [10, 25, 50, 100, 500],
+        [10, 25, 50, 100, 500],
+      ],
+      columnDefs: [
+        {
+          orderable: true,
+          searchable: true,
+          className: 'center',
+          targets: [0, 1],
+        },
+      ],
+      searching: true,
+      processing: true,
+      serverSide: true,
+      stateSave: true,
+      ajax: {
+        url: LIST_JSON_URL,
+        type: 'POST',
+        data: { data: JSON.stringify(data) },
+        traditional: true,
+        dataType: 'json',
+      },
+      dom:
+        "<'row'<'col-sm-1'B><'col-sm-6'l><'col-sm-5'f>>" +
+        "<'row'<'col-sm-12'tr>>" +
+        "<'row'<'col-sm-5'i><'col-sm-7'p>>",
+      buttons: [
+        {
+          extend: 'csv',
+          filename: exportFileName,
+          action: exportAction,
+          exportOptions: {
+            columns: ':visible :not(.actions)',
+          },
+        },
+      ],
+      responsive: true,
+    });
+  });
+
   $('#report').on('click', '#reset', function () {
     const table = $('.datatable').DataTable();
 

--- a/tally_ho/apps/tally/static/js/get_centers_stations.js
+++ b/tally_ho/apps/tally/static/js/get_centers_stations.js
@@ -1,6 +1,6 @@
 $(document).ready(function () {
   $('#centers').change(function () {
-    const center_ids = $('.selectpicker').val();
+    const center_ids = $('#centers').val();
 
     if (center_ids) {
       $.ajax({
@@ -21,6 +21,29 @@ $(document).ready(function () {
     } else {
       $('.center-stations').selectpicker('deselectAll');
       $('.center-stations').selectpicker('refresh');
+    }
+  });
+  $('#filter-in-centers').change(function () {
+    const center_ids = $('#filter-in-centers').val();
+    if (center_ids) {
+      $.ajax({
+        url: getCentersStationsUrl,
+        data: {
+          data: JSON.stringify({
+            center_ids: center_ids,
+            tally_id: tallyId,
+          }),
+        },
+        traditional: true,
+        dataType: 'json',
+        success: (data) => {
+          const { station_ids } = data;
+          $('.filter-in-center-stations').selectpicker('val', station_ids);
+        },
+      });
+    } else {
+      $('.filter-in-center-stations').selectpicker('deselectAll');
+      $('.filter-in-center-stations').selectpicker('refresh');
     }
   });
 });

--- a/tally_ho/apps/tally/templates/reports/form_results.html
+++ b/tally_ho/apps/tally/templates/reports/form_results.html
@@ -26,7 +26,15 @@
       <button style="float: left; margin-bottom: 2em;" id="export-form-results-presidential" class="btn btn-default btn-small">{% trans 'Export Presidential Results in JSON' %}</button>
       <button style="float: left; margin-left: 1em; margin-bottom: 2em;" id="export-form-results-parliamentary" class="btn btn-default btn-small">{% trans 'Export Parliamentary Results in JSON' %}</button>
     </div>
-    <div class="col-sm-4">
+    <div class="col-sm-3">
+      <p style="text-align: left; margin-left: .5em;">Races</p>
+      <select class="selectpicker" id="filter-out-race-types" name="report_length" aria-controls="report" multiple data-actions-box="true" title="Select Race Type">
+        {% for race_type in race_types %}
+          <option value={{race_type.name}}>{{race_type.name}}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-sm-3">
       <p style="text-align: left; margin-left: .5em;">Centers</p>
       <select class="selectpicker" id="centers" name="report_length" aria-controls="report" multiple data-actions-box="true" title="Select Centers">
         {% for center in centers %}
@@ -34,7 +42,7 @@
         {% endfor %}
       </select>
     </div>
-    <div class="col-sm-4">
+    <div class="col-sm-3">
       <p style="text-align: left; margin-left: .5em;">{% trans 'Stations' %}</p>
       <select class="selectpicker center-stations" id="stations" name="report_length" aria-controls="report" multiple data-actions-box="true" title="Select Stations">
         {% for station in stations %}
@@ -42,7 +50,7 @@
         {% endfor %}
       </select>
     </div>
-    <div class="col-sm-4">
+    <div class="col-sm-3">
       <div class="card">
         <div class="card-body">
           <p class="card-text" style="text-align: left;">{% trans 'Filter out Centers and Stations from results.' %}</p>
@@ -55,7 +63,15 @@
 </caption>
   <caption style="margin-top: 2em; margin-left: -0.5em; margin-bottom: 2em;">
     <div id="in-report" class="row">
-    <div class="col-sm-4">
+    <div class="col-sm-3">
+      <p style="text-align: left; margin-left: .5em;">Races</p>
+      <select class="selectpicker" id="filter-in-race-types" name="report_length" aria-controls="report" multiple data-actions-box="true" title="Select Race Type">
+        {% for race_type in race_types %}
+          <option value={{race_type.name}}>{{race_type.name}}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-sm-3">
       <p style="text-align: left; margin-left: .5em;">Centers</p>
       <select class="selectpicker" id="filter-in-centers" name="report_length" aria-controls="report" multiple data-actions-box="true" title="Select Centers">
         {% for center in centers %}
@@ -63,7 +79,7 @@
         {% endfor %}
       </select>
     </div>
-    <div class="col-sm-4">
+    <div class="col-sm-3">
       <p style="text-align: left; margin-left: .5em;">Stations</p>
       <select class="selectpicker filter-in-center-stations" id="filter-in-stations" name="report_length" aria-controls="report" multiple data-actions-box="true" title="Select Stations">
         {% for station in stations %}
@@ -71,7 +87,7 @@
         {% endfor %}
       </select>
     </div>
-    <div class="col-sm-4">
+    <div class="col-sm-3">
       <div class="card">
         <div class="card-body">
           <p class="card-text" style="text-align: left;">Filter Centers and Stations from results.</p>

--- a/tally_ho/apps/tally/templates/reports/form_results.html
+++ b/tally_ho/apps/tally/templates/reports/form_results.html
@@ -27,7 +27,7 @@
       <button style="float: left; margin-left: 1em; margin-bottom: 2em;" id="export-form-results-parliamentary" class="btn btn-default btn-small">{% trans 'Export Parliamentary Results in JSON' %}</button>
     </div>
     <div class="col-sm-3">
-      <p style="text-align: left; margin-left: .5em;">Races</p>
+      <p style="text-align: left; margin-left: .5em;">{% trans  'Races' %}</p>
       <select class="selectpicker" id="filter-out-race-types" name="report_length" aria-controls="report" multiple data-actions-box="true" title="Select Race Type">
         {% for race_type in race_types %}
           <option value={{race_type.name}}>{{race_type.name}}</option>
@@ -35,7 +35,7 @@
       </select>
     </div>
     <div class="col-sm-3">
-      <p style="text-align: left; margin-left: .5em;">Centers</p>
+      <p style="text-align: left; margin-left: .5em;">{% trans 'Centers' %}</p>
       <select class="selectpicker" id="centers" name="report_length" aria-controls="report" multiple data-actions-box="true" title="Select Centers">
         {% for center in centers %}
           <option value={{center.id}}>{{center.name}}</option>
@@ -53,7 +53,7 @@
     <div class="col-sm-3">
       <div class="card">
         <div class="card-body">
-          <p class="card-text" style="text-align: left;">{% trans 'Filter out Centers and Stations from results.' %}</p>
+          <p class="card-text" style="text-align: left;">{% trans 'Filter Out.' %}</p>
           <button style="float: left;" id="filter-report" class="btn btn-default btn-small">{% trans 'Apply' %}</button>
           <a href='.' style="float: left; margin-left: 1em;" class="btn btn-default btn-small">{% trans 'Reset' %}</a>
         </div>
@@ -64,7 +64,7 @@
   <caption style="margin-top: 2em; margin-left: -0.5em; margin-bottom: 2em;">
     <div id="in-report" class="row">
     <div class="col-sm-3">
-      <p style="text-align: left; margin-left: .5em;">Races</p>
+      <p style="text-align: left; margin-left: .5em;">{% trans 'Races' %}</p>
       <select class="selectpicker" id="filter-in-race-types" name="report_length" aria-controls="report" multiple data-actions-box="true" title="Select Race Type">
         {% for race_type in race_types %}
           <option value={{race_type.name}}>{{race_type.name}}</option>
@@ -72,7 +72,7 @@
       </select>
     </div>
     <div class="col-sm-3">
-      <p style="text-align: left; margin-left: .5em;">Centers</p>
+      <p style="text-align: left; margin-left: .5em;">{% trans  'Centers' %}</p>
       <select class="selectpicker" id="filter-in-centers" name="report_length" aria-controls="report" multiple data-actions-box="true" title="Select Centers">
         {% for center in centers %}
           <option value={{center.id}}>{{center.name}}</option>
@@ -80,7 +80,7 @@
       </select>
     </div>
     <div class="col-sm-3">
-      <p style="text-align: left; margin-left: .5em;">Stations</p>
+      <p style="text-align: left; margin-left: .5em;">{% trans 'Stations' %}</p>
       <select class="selectpicker filter-in-center-stations" id="filter-in-stations" name="report_length" aria-controls="report" multiple data-actions-box="true" title="Select Stations">
         {% for station in stations %}
           <option value={{station.id}}>{{station.id}}</option>
@@ -90,9 +90,9 @@
     <div class="col-sm-3">
       <div class="card">
         <div class="card-body">
-          <p class="card-text" style="text-align: left;">Filter Centers and Stations from results.</p>
-          <button style="float: left;" id="filter-in-report" class="btn btn-default btn-small">Apply</button>
-          <a href='.' style="float: left; margin-left: 1em;" class="btn btn-default btn-small">Reset</a>
+          <p class="card-text" style="text-align: left;">{% trans 'Filter In.' %}</p>
+          <button style="float: left;" id="filter-in-report" class="btn btn-default btn-small">{% trans 'Apply' %}</button>
+          <a href='.' style="float: left; margin-left: 1em;" class="btn btn-default btn-small">{% trans 'Reset' %}</a>
         </div>
       </div>
     </div>

--- a/tally_ho/apps/tally/templates/reports/form_results.html
+++ b/tally_ho/apps/tally/templates/reports/form_results.html
@@ -53,6 +53,35 @@
     </div>
   </div>
 </caption>
+  <caption style="margin-top: 2em; margin-left: -0.5em; margin-bottom: 2em;">
+    <div id="in-report" class="row">
+    <div class="col-sm-4">
+      <p style="text-align: left; margin-left: .5em;">Centers</p>
+      <select class="selectpicker" id="filter-in-centers" name="report_length" aria-controls="report" multiple data-actions-box="true" title="Select Centers">
+        {% for center in centers %}
+          <option value={{center.id}}>{{center.name}}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-sm-4">
+      <p style="text-align: left; margin-left: .5em;">Stations</p>
+      <select class="selectpicker filter-in-center-stations" id="filter-in-stations" name="report_length" aria-controls="report" multiple data-actions-box="true" title="Select Stations">
+        {% for station in stations %}
+          <option value={{station.id}}>{{station.id}}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-sm-4">
+      <div class="card">
+        <div class="card-body">
+          <p class="card-text" style="text-align: left;">Filter Centers and Stations from results.</p>
+          <button style="float: left;" id="filter-in-report" class="btn btn-default btn-small">Apply</button>
+          <a href='.' style="float: left; margin-left: 1em;" class="btn btn-default btn-small">Reset</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</caption>
 <br>
   <thead>
       <tr>


### PR DESCRIPTION
Have an extra `Races` field in the filters that filter out by race type. Duplicate this and reverse the logic to work with filtering results. 
The results can be filtered in or out based on race, center or station selected.

Fixes https://github.com/onaio/tally-ho/issues/360
Fixes https://github.com/onaio/tally-ho/issues/358

