### PR TITLE
Remove total field from Presidential Summary Report

### DIFF
--- a/tally_ho/apps/tally/tests/views/reports/test_election_statistics_report.py
+++ b/tally_ho/apps/tally/tests/views/reports/test_election_statistics_report.py
@@ -106,8 +106,7 @@ class TestElectionStatisticsReports(TestBase):
         for stat in election_stats:
             for field in fields:
                 self.assertIn(field, stat)
-        total = election_stats.pop()
-        self.assertEqual(total['ballot_number'], 'Total')
+
         aggregate = {}
         for stat in election_stats:
             for record, value in enumerate(stat):
@@ -116,6 +115,3 @@ class TestElectionStatisticsReports(TestBase):
                         aggregate[record] += value
                     else:
                         aggregate[record] = value
-
-        for key, val in enumerate(aggregate):
-            self.assertEqual(total[key], val)

--- a/tally_ho/apps/tally/views/reports/election_statistics_report.py
+++ b/tally_ho/apps/tally/views/reports/election_statistics_report.py
@@ -88,13 +88,14 @@ def generate_election_statistics(tally_id, election_level, gender=None):
         )
     ]
 
-    aggregate_ballot_election_statistics = {
-        'ballot_number': 'Total',
-        'stations_expected': 0,
-        'stations_counted': 0,
-        'voters_in_counted_stations': 0,
-        'registrants_in_stations_counted': 0,
-    }
+    if election_level != 'Presidential':
+        aggregate_ballot_election_statistics = {
+            'ballot_number': 'Total',
+            'stations_expected': 0,
+            'stations_counted': 0,
+            'voters_in_counted_stations': 0,
+            'registrants_in_stations_counted': 0,
+        }
 
     for ballot in election_level_ballots:
         voters_in_counted_stations = 0
@@ -113,8 +114,9 @@ def generate_election_statistics(tally_id, election_level, gender=None):
             [station for station in stations\
                 if station.get('ballot_id') == ballot.get('id')]
         ballot_election_statistics['stations_expected'] = len(ballot_stations)
-        aggregate_ballot_election_statistics['stations_expected'] += \
-            ballot_election_statistics['stations_expected']
+        if election_level != 'Presidential':
+            aggregate_ballot_election_statistics['stations_expected'] += \
+                ballot_election_statistics['stations_expected']
 
         ballot_stations_with_archived_forms =\
             [station for station in ballot_stations\
@@ -194,33 +196,35 @@ def generate_election_statistics(tally_id, election_level, gender=None):
                     100 * voters_in_counted_stations /
                     registrants_in_stations_counted,
                     2) if registrants_in_stations_counted else 0
-            aggregate_ballot_election_statistics['stations_counted'] += \
-                ballot_election_statistics['stations_counted']
+            if election_level != 'Presidential':
+                aggregate_ballot_election_statistics['stations_counted'] += \
+                    ballot_election_statistics['stations_counted']
+                aggregate_ballot_election_statistics[
+                    'voters_in_counted_stations'] += ballot_election_statistics[
+                    'voters_in_counted_stations']
+                aggregate_ballot_election_statistics[
+                    'registrants_in_stations_counted'] += \
+                    ballot_election_statistics['registrants_in_stations_counted']
+        if election_level != 'Presidential':
             aggregate_ballot_election_statistics[
-                'voters_in_counted_stations'] += ballot_election_statistics[
-                'voters_in_counted_stations']
+                'percentage_of_stations_counted'] = round(
+                100 * aggregate_ballot_election_statistics['stations_counted'] /
+                aggregate_ballot_election_statistics[
+                    'stations_expected'],
+                2) if aggregate_ballot_election_statistics[
+                    'stations_expected'] else 0.0
             aggregate_ballot_election_statistics[
-                'registrants_in_stations_counted'] += \
-                ballot_election_statistics['registrants_in_stations_counted']
-
-        aggregate_ballot_election_statistics[
-            'percentage_of_stations_counted'] = round(
-            100 * aggregate_ballot_election_statistics['stations_counted'] /
-            aggregate_ballot_election_statistics[
-                'stations_expected'],
-            2) if aggregate_ballot_election_statistics[
-                'stations_expected'] else 0.0
-        aggregate_ballot_election_statistics[
-            'percentage_turnout_in_stations_counted'] = round(
-            100 * aggregate_ballot_election_statistics[
-                'voters_in_counted_stations'] /
-            aggregate_ballot_election_statistics[
-                'registrants_in_stations_counted'],
-            2) if aggregate_ballot_election_statistics[
-            'registrants_in_stations_counted'] else 0.0
+                'percentage_turnout_in_stations_counted'] = round(
+                100 * aggregate_ballot_election_statistics[
+                    'voters_in_counted_stations'] /
+                aggregate_ballot_election_statistics[
+                    'registrants_in_stations_counted'],
+                2) if aggregate_ballot_election_statistics[
+                'registrants_in_stations_counted'] else 0.0
 
         election_statistics.append(ballot_election_statistics)
-    election_statistics.append(aggregate_ballot_election_statistics)
+    if election_level != 'Presidential':
+        election_statistics.append(aggregate_ballot_election_statistics)
     return election_statistics
 
 

--- a/tally_ho/apps/tally/views/reports/election_statistics_report.py
+++ b/tally_ho/apps/tally/views/reports/election_statistics_report.py
@@ -200,15 +200,17 @@ def generate_election_statistics(tally_id, election_level, gender=None):
                 aggregate_ballot_election_statistics['stations_counted'] += \
                     ballot_election_statistics['stations_counted']
                 aggregate_ballot_election_statistics[
-                    'voters_in_counted_stations'] += ballot_election_statistics[
-                    'voters_in_counted_stations']
+                    'voters_in_counted_stations'] += \
+                    ballot_election_statistics['voters_in_counted_stations']
                 aggregate_ballot_election_statistics[
                     'registrants_in_stations_counted'] += \
-                    ballot_election_statistics['registrants_in_stations_counted']
+                    ballot_election_statistics[
+                        'registrants_in_stations_counted']
         if election_level != 'Presidential':
             aggregate_ballot_election_statistics[
                 'percentage_of_stations_counted'] = round(
-                100 * aggregate_ballot_election_statistics['stations_counted'] /
+                100 * aggregate_ballot_election_statistics[
+                    'stations_counted'] /
                 aggregate_ballot_election_statistics[
                     'stations_expected'],
                 2) if aggregate_ballot_election_statistics[


### PR DESCRIPTION
 This is because there will be only one presidential candidate per ballot and hence no need to have an aggregate row on this reports page

fixes https://github.com/onaio/tally-ho/issues/425