### PR TITLE
Remove n+1 query issue when getting tally station and reconcilliation_form 

### DIFF
--- a/tally_ho/apps/tally/models/result_form.py
+++ b/tally_ho/apps/tally/models/result_form.py
@@ -318,18 +318,18 @@ class ResultForm(BaseModel):
 
         :returns: The final reconciliation form for this result form.
         """
-        # Use .all() to leverage prefetch_related cache
-        final = [
-            recon for recon in self.reconciliationform_set.all()
-            if recon.active and recon.entry_version == EntryVersion.FINAL
-        ]
+        final = self.reconciliationform_set.filter(
+            active=True, entry_version=EntryVersion.FINAL
+        )
+        final_count = final.count()
 
-        if len(final) == 0:
+        if final_count == 0:
             return False
 
-        len(final) > 1 and clean_reconciliation_forms(final)
+        # raises SuspiciousOperation exeption if there is an issue.
+        clean_reconciliation_forms(final)
 
-        return final[0]
+        return final.first()
 
     @property
     def reconciliationform_exists(self):

--- a/tally_ho/libs/views/exports.py
+++ b/tally_ho/libs/views/exports.py
@@ -132,7 +132,15 @@ def build_candidate_results_output(result_form):
         'number_registrants': station.registrants if station else None
     }
 
-    recon = result_form.reconciliationform
+    # Use prefetched final_reconciliations if available, else fall back to property
+    if hasattr(result_form, "final_reconciliations"):
+        recon = (
+            result_form.final_reconciliations[0]
+            if result_form.final_reconciliations
+            else None
+        )
+    else:
+        recon = result_form.reconciliationform
 
     if recon:
         output.update({


### PR DESCRIPTION
Part of the fixes for https://github.com/onaio/tallyho-infra/issues/12 specifically this [comment](https://github.com/onaio/tally-ho/pull/544#pullrequestreview-3659221512)

Affects Candidate Results page https://tallyho.onalabs.org/super-administrator/candidate-results/1/
```
Analysis Summary

  Improvements Achieved (85% reduction)
  ┌─────────────────┬────────┬────────┬─────────────┐
  │      Table      │ Before │ After  │ Improvement │
  ├─────────────────┼────────┼────────┼─────────────┤
  │ tally_result    │ 55,096 │ 2      │ 99.99% ✅   │
  ├─────────────────┼────────┼────────┼─────────────┤
  │ tally_candidate │ 2,578  │ 2      │ 99.92% ✅   │
  ├─────────────────┼────────┼────────┼─────────────┤
  │ tally_office    │ 2,578  │ 0      │ 100% ✅     │
  ├─────────────────┼────────┼────────┼─────────────┤
  │ TOTAL           │ 70,606 │ 10,370 │ 85%         │
  └─────────────────┴────────┴────────┴─────────────┘
  Remaining N+1 Problems

  1. tally_station: 7,742 queries
  - Each query is repeated 12 times (once per candidate per form)
  - Root cause: result_form.station.registrants in build_candidate_results_output() (exports.py:130)
  - The station property (result_form.py:210) uses .filter() which bypasses prefetch:
  stations = self.center.stations.filter(station_number=self.station_number)

  2. tally_reconciliationform: 2,580 queries
  - Root cause: result_form.reconciliationform in build_candidate_results_output() (exports.py:133)
  - The reconciliationform property (result_form.py:321) uses .filter() which bypasses prefetch:
  final = self.reconciliationform_set.filter(active=True, entry_version=EntryVersion.FINAL)

```

_Originally posted by @ukanga in https://github.com/onaio/tally-ho/pull/544#pullrequestreview-3659221512_
            