### PR TITLE
Add --reset-passwords flag to migrate_users_tally command

### DIFF
--- a/tally_ho/apps/tally/management/commands/migrate_users_tally.py
+++ b/tally_ho/apps/tally/management/commands/migrate_users_tally.py
@@ -26,6 +26,10 @@ class Command(BaseCommand):
         "    # Migrate all except certain users\n"
         "    python manage.py migrate_users_tally --source-tally 2 "
         "--target-tally 5 --all-users --exclude-usernames 'admin,super_user'\n"
+        "\n"
+        "    # Migrate and reset passwords (prompts password change on login)\n"
+        "    python manage.py migrate_users_tally --source-tally 2 "
+        "--target-tally 5 --all-users --reset-passwords\n"
     )
 
     def create_parser(self, prog_name, subcommand, **kwargs):
@@ -67,6 +71,12 @@ class Command(BaseCommand):
             help="Keep administrated_tallies associations (default: False)",
         )
         parser.add_argument(
+            "--reset-passwords",
+            action="store_true",
+            help="Reset user passwords to their usernames and prompt "
+                 "password change on first login (default: False)",
+        )
+        parser.add_argument(
             "--dry-run",
             action="store_true",
             help="Preview changes without making them",
@@ -79,6 +89,7 @@ class Command(BaseCommand):
         usernames = options.get("usernames")
         exclude_usernames = options.get("exclude_usernames")
         preserve_admin_tallies = options["preserve_admin_tallies"]
+        reset_passwords = options["reset_passwords"]
         dry_run = options["dry_run"]
 
         # Validate arguments
@@ -154,6 +165,7 @@ class Command(BaseCommand):
         self.stdout.write(
             f"  Preserve admin tallies: {preserve_admin_tallies}"
         )
+        self.stdout.write(f"  Reset passwords: {reset_passwords}")
         self.stdout.write(f"  Dry run: {dry_run}")
         self.stdout.write("")
 
@@ -197,7 +209,15 @@ class Command(BaseCommand):
 
                         # Update user's tally
                         user.tally = target_tally
-                        user.save(update_fields=["tally"])
+                        update_fields = ["tally"]
+
+                        if reset_passwords:
+                            user.reset_password = True
+                            update_fields.extend(
+                                ["password", "reset_password"]
+                            )
+
+                        user.save(update_fields=update_fields)
 
                         # Remove admin tallies if not preserving
                         if (

--- a/tally_ho/apps/tally/tests/management/commands/test_migrate_users_tally.py
+++ b/tally_ho/apps/tally/tests/management/commands/test_migrate_users_tally.py
@@ -259,6 +259,55 @@ class TestMigrateUsersTallyCommand(TestCase):
 
         self.assertIn("No users found to migrate", output)
 
+    def test_reset_passwords(self):
+        """Test that --reset-passwords resets passwords to usernames and
+        sets reset_password=True so users are prompted to change on login"""
+        # First set reset_password to False to simulate users who have
+        # already changed their password
+        self.user1.reset_password = False
+        self.user1.save(update_fields=["reset_password"])
+        self.user2.reset_password = False
+        self.user2.save(update_fields=["reset_password"])
+
+        self.call_command_with_output(
+            source_tally=self.source_tally.id,
+            target_tally=self.target_tally.id,
+            usernames="user1,user2",
+            reset_passwords=True
+        )
+
+        self.user1.refresh_from_db()
+        self.user2.refresh_from_db()
+
+        # Tally should be updated
+        self.assertEqual(self.user1.tally, self.target_tally)
+        self.assertEqual(self.user2.tally, self.target_tally)
+
+        # reset_password should be True
+        self.assertTrue(self.user1.reset_password)
+        self.assertTrue(self.user2.reset_password)
+
+        # Password should be reset to username
+        self.assertTrue(self.user1.check_password("user1"))
+        self.assertTrue(self.user2.check_password("user2"))
+
+    def test_migrate_without_reset_passwords(self):
+        """Test that without --reset-passwords, passwords are unchanged"""
+        self.user1.set_password("custom_password")
+        self.user1.reset_password = False
+        self.user1.save()
+
+        self.call_command_with_output(
+            source_tally=self.source_tally.id,
+            target_tally=self.target_tally.id,
+            usernames="user1"
+        )
+
+        self.user1.refresh_from_db()
+        self.assertEqual(self.user1.tally, self.target_tally)
+        self.assertFalse(self.user1.reset_password)
+        self.assertTrue(self.user1.check_password("custom_password"))
+
     def test_migration_output_formatting(self):
         """Test that output contains expected information"""
         output = self.call_command_with_output(


### PR DESCRIPTION
## Summary

- Add `--reset-passwords` flag to `migrate_users_tally` management command
- When set, resets user passwords to their usernames and sets `reset_password=True`
- On first login, users are redirected to the password change page (existing login flow in `profile.py`)
- After changing password, `PasswordChangeForm` sets `reset_password=False` and logins proceed normally

## Changes

- **`migrate_users_tally.py`** - Added `--reset-passwords` argument. When set, includes `password` and `reset_password` in `update_fields` so `UserProfile.save()` resets the password to the username.
- **`test_migrate_users_tally.py`** - Added 2 tests:
  - `test_reset_passwords` - verifies passwords are reset and `reset_password=True`
  - `test_migrate_without_reset_passwords` - verifies passwords are unchanged without the flag

## Test plan

- [x] `test_reset_passwords` - passwords reset to usernames, `reset_password=True`
- [x] `test_migrate_without_reset_passwords` - existing behavior preserved
- [x] All 15 tests pass with no regressions

Closes #552