### PR TITLE
Make FormActionView Review open read-only audit detail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ local_settings.py
 # vim temp files
 *.sw?
 .python-version
+.worktrees

--- a/tally_ho/apps/tally/templates/audit/review_read_only.html
+++ b/tally_ho/apps/tally/templates/audit/review_read_only.html
@@ -1,0 +1,86 @@
+{% extends 'base.html' %}
+
+{% load i18n static app_filters %}
+
+{% block content %}
+
+<div class="container main-container">
+<div class="row">
+    <h1>{% trans 'Audit Review' %}</h1>
+</div>
+{% include 'center_details.html' %}
+
+{% if audit %}
+<div class="row">
+<h1>{% trans 'Quarantined Form' %}</h1>
+<hr>
+</div>
+{% for check in audit.quarantine_checks.all %}
+<div class="row">
+    <p>
+        {% trans 'Failed quarantine check:' %}
+        <b>{{ check.local_name }}</b>
+        <a class="btn btn-xs btn-link" data-toggle="collapse" href="#check-details-{{ check.pk }}">
+            {% trans 'View Details' %}
+        </a>
+    </p>
+
+    {% include "quarantine_check_details.html" with result_form=result_form check=check %}
+</div>
+{% endfor %}
+
+<div class="row audit-form border-top">
+    <div class="row">
+        <div class="col-md-2 col-sm-1 grid2">
+            {% if audit.blank_reconciliation or audit.blank_results or audit.unclear_figures or audit.damaged_form or audit.other %}
+            <h3 style="margin-top: 0;">{% trans "Problem" %}</h3>
+            {% endif %}
+            {% if audit.blank_reconciliation %}
+             <p><label>{% trans "Blank reconciliation" %}</label></p>
+            {% endif %}
+            {% if audit.blank_results %}
+             <p><label>{% trans "Blank results" %}</label></p>
+            {% endif %}
+            {% if audit.unclear_figures %}
+             <p><label>{% trans "Unclear figures" %}</label></p>
+            {% endif %}
+            {% if audit.damaged_form %}
+              <p><label>{% trans "Damaged form" %}</label></p>
+            {% endif %}
+            {% if audit.other %}
+             <p class="large"><label class="wrap_label">
+                {% trans "Other:" %}</label> {{ audit.other }}</p>
+            {% endif %}
+
+            <h3>{% trans "Action Prior to Recommendation" %}</h3>
+            <p><label>{% trans "Action prior to recommendation:" %}</label>
+                {{ audit.action_prior_name }}
+            </p>
+            <p><label>{% trans "Resolution recommendation:" %}</label>
+                {{ audit.resolution_recommendation_name }}
+            </p>
+        </div>
+        <div class="col-md-2 col-sm-1 grid2 righter">
+            {% if audit.team_comment %}
+                <p><label>{% trans "Team comment:" %}</label>
+                    {{ audit.team_comment }}
+                </p>
+            {% endif %}
+            {% if audit.supervisor_comment %}
+                <p><label>{% trans "Supervisor comment:" %}</label>
+                    {{ audit.supervisor_comment }}
+                </p>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endif %}
+
+<div class="row" style="margin-top: 20px;">
+    <a class="btn btn-default" href="{% url 'form-action-view' tally_id=tally_id %}">
+        {% trans "Back to Approval Queue" %}
+    </a>
+</div>
+</div>
+
+{% endblock %}

--- a/tally_ho/apps/tally/tests/views/test_super_admin.py
+++ b/tally_ho/apps/tally/tests/views/test_super_admin.py
@@ -88,7 +88,8 @@ class TestSuperAdmin(TestBase):
         response = view(request, tally_id=tally.pk)
 
         self.assertEqual(response.status_code, 302)
-        self.assertIn("/audit/review", response["Location"])
+        self.assertIn("/super-administrator/audit-review-detail",
+                      response["Location"])
 
     def test_form_action_view_post_confirm_audit(self):
         tally = create_tally()
@@ -131,6 +132,111 @@ class TestSuperAdmin(TestBase):
         self.assertIn(
             "/super-administrator/form-action-list", response["Location"]
         )
+
+    def test_form_action_review_redirects_to_read_only_detail(self):
+        """FormActionView 'Review' button must redirect to the read-only
+        audit-review-detail view, NOT the editable ReviewView."""
+        tally = create_tally()
+        tally.users.add(self.user)
+        result_form = create_result_form(
+            form_state=FormState.AUDIT, tally=tally
+        )
+        view = views.FormActionView.as_view()
+        data = {"result_form": result_form.pk, "review": 1}
+        request = self.factory.post("/", data=data)
+        request.user = self.user
+        request.session = {"result_form": result_form.pk}
+        response = view(request, tally_id=tally.pk)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(
+            "/super-administrator/audit-review-detail",
+            response["Location"],
+        )
+        self.assertNotIn("/audit/review", response["Location"])
+
+    def test_audit_review_detail_view_get(self):
+        """AuditReviewDetailView returns 200 with audit context."""
+        tally = create_tally()
+        tally.users.add(self.user)
+        result_form = create_result_form(
+            form_state=FormState.AUDIT, tally=tally
+        )
+        audit = create_audit(result_form, self.user)
+        audit.reviewed_supervisor = True
+        audit.for_superadmin = True
+        audit.resolution_recommendation = 4  # MAKE_AVAILABLE_FOR_ARCHIVE
+        audit.save()
+
+        view = views.AuditReviewDetailView.as_view()
+        request = self.factory.get("/")
+        request.user = self.user
+        request.session = {"result_form": result_form.pk}
+        response = view(request, tally_id=tally.pk)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("audit", response.context_data)
+        self.assertIn("result_form", response.context_data)
+        self.assertEqual(response.context_data["audit"].pk, audit.pk)
+
+    def test_audit_review_detail_view_rejects_post(self):
+        """AuditReviewDetailView must not accept POST requests."""
+        tally = create_tally()
+        tally.users.add(self.user)
+        result_form = create_result_form(
+            form_state=FormState.AUDIT, tally=tally
+        )
+        audit = create_audit(result_form, self.user)
+        audit.reviewed_supervisor = True
+        audit.for_superadmin = True
+        audit.save()
+
+        view = views.AuditReviewDetailView.as_view()
+        request = self.factory.post("/", data={})
+        request.user = self.user
+        request.session = {"result_form": result_form.pk}
+        response = view(request, tally_id=tally.pk)
+
+        self.assertEqual(response.status_code, 405)
+
+    def test_form_action_confirm_preserves_audit_resolution(self):
+        """FormActionView 'Confirm' must not change the audit's
+        resolution_recommendation — it should only deactivate the audit
+        and send the form to DATA_ENTRY_1."""
+        from tally_ho.libs.models.enums.audit_resolution import \
+            AuditResolution
+
+        tally = create_tally()
+        tally.users.add(self.user)
+        result_form = create_result_form(
+            form_state=FormState.AUDIT, tally=tally
+        )
+        create_reconciliation_form(result_form, self.user)
+        create_reconciliation_form(result_form, self.user)
+        create_candidates(result_form, self.user)
+        audit = create_audit(result_form, self.user)
+        audit.reviewed_supervisor = True
+        audit.for_superadmin = True
+        audit.resolution_recommendation = \
+            AuditResolution.MAKE_AVAILABLE_FOR_ARCHIVE
+        audit.save()
+
+        view = views.FormActionView.as_view()
+        data = {"result_form": result_form.pk, "confirm": 1}
+        request = self.factory.post("/", data=data)
+        request.user = self.user
+        request.session = {"result_form": result_form.pk}
+        view(request, tally_id=tally.pk)
+
+        audit.reload()
+        result_form.reload()
+        self.assertFalse(audit.active)
+        self.assertEqual(
+            audit.resolution_recommendation,
+            AuditResolution.MAKE_AVAILABLE_FOR_ARCHIVE,
+        )
+        self.assertEqual(result_form.form_state, FormState.DATA_ENTRY_1)
+        self.assertTrue(result_form.skip_quarantine_checks)
 
     def test_result_export_view(self):
         tally = create_tally()

--- a/tally_ho/apps/tally/views/super_admin.py
+++ b/tally_ho/apps/tally/views/super_admin.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import User
 from django.contrib.messages.views import SuccessMessageMixin
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.core.exceptions import SuspiciousOperation
+from django.forms import model_to_dict
 from django.db.models import Case, Count, F, FloatField, Q, Value, When
 from django.db.models.deletion import ProtectedError
 from django.db.models.functions import Cast
@@ -22,6 +23,7 @@ from guardian.mixins import LoginRequiredMixin
 from reversion.models import Version
 
 from tally_ho.apps.tally.forms.barcode_form import ResultFormSearchBarcodeForm
+from tally_ho.apps.tally.forms.recon_form import ReconForm
 from tally_ho.apps.tally.forms.confirm_reset_form import ConfirmResetForm
 from tally_ho.apps.tally.forms.create_ballot_form import CreateBallotForm
 from tally_ho.apps.tally.forms.create_center_form import CreateCenterForm
@@ -56,6 +58,7 @@ from tally_ho.apps.tally.models.result_form import ResultForm
 from tally_ho.apps.tally.models.station import Station
 from tally_ho.apps.tally.models.tally import Tally
 from tally_ho.apps.tally.models.user_profile import UserProfile
+from tally_ho.apps.tally.views.quality_control import result_form_results
 from tally_ho.apps.tally.views.constants import (
     at_state_query_param,
     election_level_query_param,
@@ -1191,6 +1194,37 @@ class FormActionView(
             return redirect(self.success_url, tally_id=tally_id)
         else:
             raise SuspiciousOperation("Unknown POST response type")
+
+
+class AuditReviewDetailView(
+    LoginRequiredMixin,
+    GroupRequiredMixin,
+    TallyAccessMixin,
+    TemplateView,
+):
+    group_required = groups.SUPER_ADMINISTRATOR
+    template_name = "audit/review_read_only.html"
+
+    def get(self, *args, **kwargs):
+        tally_id = kwargs["tally_id"]
+        pk = self.request.session.get("result_form")
+        result_form = get_object_or_404(
+            ResultForm, pk=pk, tally__id=tally_id
+        )
+        audit = result_form.audit
+
+        reconciliation_form = ReconForm(data=model_to_dict(
+            result_form.reconciliationform
+        )) if result_form.reconciliationform else None
+        results = result_form_results(result_form)
+
+        return self.render_to_response(self.get_context_data(
+            audit=audit,
+            result_form=result_form,
+            tally_id=tally_id,
+            reconciliation_form=reconciliation_form,
+            results=results,
+        ))
 
 
 class CreateCenterView(

--- a/tally_ho/apps/tally/views/super_admin.py
+++ b/tally_ho/apps/tally/views/super_admin.py
@@ -1179,7 +1179,7 @@ class FormActionView(
         self.request.session["result_form"] = result_form.pk
 
         if "review" in post_data:
-            return redirect("audit-review", tally_id=tally_id)
+            return redirect("audit-review-detail", tally_id=tally_id)
         elif "confirm" in post_data:
             result_form.previous_form_state = result_form.form_state
             result_form.user = self.request.user.userprofile

--- a/tally_ho/urls.py
+++ b/tally_ho/urls.py
@@ -574,6 +574,12 @@ urlpatterns = [
         name="form-action-view",
     ),
     re_path(
+        r"^super-administrator/audit-review-detail/"
+        r"(?P<tally_id>(\d+))/$",
+        super_admin.AuditReviewDetailView.as_view(),
+        name="audit-review-detail",
+    ),
+    re_path(
         r"^super-administrator/duplicate-result-tracking/"
         r"(?P<tally_id>(\d+))/$",
         super_admin.DuplicateResultTrackingView.as_view(),


### PR DESCRIPTION
## Problem

Fixes https://github.com/onaio/tallyho-infra/issues/18

When a super admin clicks "Review" on a form in the approval queue, `FormActionView` redirects to the editable `ReviewView` used by audit clerks and supervisors. This means a super admin could accidentally overwrite the audit supervisor's decisions (resolution recommendation, comments, problem flags) when they only intended to review the form before confirming it.

## Solution

Introduced a new `AuditReviewDetailView` — a GET-only `TemplateView` that displays the audit details (quarantine checks, problem flags, action prior to recommendation, resolution recommendation, and comments) in a read-only format with no form inputs or submit buttons. The `FormActionView.post()` redirect target was changed from `audit-review` to `audit-review-detail` so the "Review" button now opens this read-only view instead.

The existing "Confirm" flow is unchanged — it still deactivates the audit and sends the form to `DATA_ENTRY_1` without modifying the supervisor's resolution recommendation.

## Changes

- **`tally_ho/apps/tally/views/super_admin.py`** — Added `AuditReviewDetailView` class; changed redirect in `FormActionView.post()` from `audit-review` to `audit-review-detail`
- **`tally_ho/urls.py`** — Added `audit-review-detail` URL route
- **`tally_ho/apps/tally/templates/audit/review_read_only.html`** — New read-only template based on the summary section of `review.html`

## Validation

- 4 new tests: redirect goes to read-only view, GET returns 200 with correct context, POST returns 405, confirm preserves audit resolution
- 1 existing test assertion updated for new redirect URL
- Full test suite passes (773 tests, 0 failures)